### PR TITLE
Add channel selection for recordings

### DIFF
--- a/src/components/RecordPlayTab.tsx
+++ b/src/components/RecordPlayTab.tsx
@@ -45,6 +45,28 @@ export default function RecordPlayTab(_props: RecordPlayTabProps) {
   );
   const [recordChannels, setRecordChannels] = useState<number[]>([1]);
   const [showChannelPicker, setShowChannelPicker] = useState(false);
+  const [rangeStart, setRangeStart] = useState(1);
+  const [rangeEnd, setRangeEnd] = useState(1);
+
+  const handleAddRange = useCallback(() => {
+    const s = Math.min(Math.max(1, rangeStart), CHANNELS);
+    const e = Math.min(Math.max(1, rangeEnd), CHANNELS);
+    const start = Math.min(s, e);
+    const end = Math.max(s, e);
+    setRecordChannels((prev) => {
+      const set = new Set(prev);
+      for (let ch = start; ch <= end; ch++) set.add(ch);
+      return Array.from(set).sort((a, b) => a - b);
+    });
+  }, [rangeStart, rangeEnd]);
+
+  const handleSelectAll = useCallback(() => {
+    setRecordChannels(Array.from({ length: CHANNELS }, (_, idx) => idx + 1));
+  }, []);
+
+  const handleClearChannels = useCallback(() => {
+    setRecordChannels([]);
+  }, []);
 
   // Data buffers: timestamps and per-channel arrays of values
   const tRef = useRef<number[]>([]);
@@ -805,6 +827,42 @@ export default function RecordPlayTab(_props: RecordPlayTabProps) {
         >
           <div className="modal" onMouseDown={(e) => e.stopPropagation()}>
             <h3>Select Channels</h3>
+            <div
+              style={{
+                display: "flex",
+                gap: 8,
+                flexWrap: "wrap",
+                marginBottom: 8,
+                alignItems: "center",
+              }}
+            >
+              <input
+                type="number"
+                min={1}
+                max={CHANNELS}
+                value={rangeStart}
+                onChange={(e) => setRangeStart(Number(e.currentTarget.value))}
+                style={{ width: 60 }}
+              />
+              <span>to</span>
+              <input
+                type="number"
+                min={1}
+                max={CHANNELS}
+                value={rangeEnd}
+                onChange={(e) => setRangeEnd(Number(e.currentTarget.value))}
+                style={{ width: 60 }}
+              />
+              <button className="btn" onClick={handleAddRange}>
+                Add Range
+              </button>
+              <button className="btn" onClick={handleSelectAll}>
+                Select All
+              </button>
+              <button className="btn" onClick={handleClearChannels}>
+                Clear
+              </button>
+            </div>
             <div
               style={{
                 display: "grid",


### PR DESCRIPTION
## Summary
- allow choosing one or multiple DMX channels in the Record/Play tab
- export only the chosen channels to WAV or JSONL, including channel list metadata
- honor JSONL channel mappings during playback
- replace channel text input with a modal of per-channel checkboxes

## Testing
- `pnpm build`
- `cargo check` *(fails: The system library `glib-2.0` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c52b6e617c8323902bc21f26427d39